### PR TITLE
fix: application labels aren't unique

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -54,7 +54,6 @@ INSTALLED_APPS = [
     'org',
     'tasks',
     'core',
-    'rest_framework',
     'drf_yasg',
 ]
 


### PR DESCRIPTION
### Description
Fix bug due to duplicate application name in INSTALLED_APPS
![image](https://user-images.githubusercontent.com/33046846/81770884-2a91f000-94ff-11ea-871d-d7790ed5806c.png)

**Type of Change:** (Delete irrelevant options)
- Code

**Code/Quality Assurance Only** (Delete irrelevant options)

- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
The server runs properly again.
![image](https://user-images.githubusercontent.com/33046846/81770929-4bf2dc00-94ff-11ea-9662-e113519262af.png)

### Checklist:
- [ X ] My PR follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code or materials

**Code/Quality Assurance**
- [ X ] My changes generate no new warnings 
